### PR TITLE
gh fix merge

### DIFF
--- a/bolt/lib/Core/Exceptions.cpp
+++ b/bolt/lib/Core/Exceptions.cpp
@@ -398,8 +398,8 @@ void BinaryFunction::updateEHRanges() {
 
         // Same symbol is used for the beginning and the end of the range.
         MCSymbol *EHSymbol;
-        if (auto InstrLabel = BC.MIB->getLabel(Instr)) {
-          EHSymbol = *InstrLabel;
+        if (MCSymbol *InstrLabel = BC.MIB->getLabel(Instr)) {
+          EHSymbol = InstrLabel;
         } else {
           std::unique_lock<llvm::sys::RWMutex> Lock(BC.CtxMutex);
           EHSymbol = BC.Ctx->createNamedTempSymbol("EH");


### PR DESCRIPTION
- Modify llvm-gsymutil to ignore invalid file indexes (#71431)
- [libc][math] Implement powf function correctly rounded to all rounding modes. (#71188)
- [Vectorize] Remove Transforms/Vectorize.h (#71294)
- [BOLT] Use direct storage for Label annotations. NFCI. (#70147)
- [flang][openacc] Support variable in equivalence in declare directive (#71242)
- [CMake][Fuchsia] Use unchecked hardening mode for libc++
- [BOLT] Use Label annotation instead of EHLabel pseudo. NFCI. (#70179)
- [BOLT] Fix build after merge
