### PR TITLE
fix empty bb

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4176,7 +4176,7 @@ void BinaryFunction::updateOutputValues(const BOLTLinker &Linker) {
         assert(PrevBB->getOutputAddressRange().first <= BBAddress &&
                "Bad output address for basic block.");
         assert((PrevBB->getOutputAddressRange().first != BBAddress ||
-                !hasInstructions() || PrevBB->empty()) &&
+                !hasInstructions() || !PrevBB->getNumNonPseudos()) &&
                "Bad output address for basic block.");
         PrevBB->setOutputEndAddress(BBAddress);
       }


### PR DESCRIPTION
- Modify llvm-gsymutil to ignore invalid file indexes (#71431)
- [libc][math] Implement powf function correctly rounded to all rounding modes. (#71188)
- [Vectorize] Remove Transforms/Vectorize.h (#71294)
- [BOLT] Use direct storage for Label annotations. NFCI. (#70147)
- [flang][openacc] Support variable in equivalence in declare directive (#71242)
- [CMake][Fuchsia] Use unchecked hardening mode for libc++
- [BOLT] Use Label annotation instead of EHLabel pseudo. NFCI. (#70179)
- [flang][openacc][NFC] Remove unused variable
- [clang] Improve `SourceManager::PrintStats()`
- [flang][openacc] Generate data bounds for array addressing. (#71254)
- [flang][openacc] Issue an error when TBP are used in data clause (#71444)
- [clang] Fix test after 4f31d32
- [BOLT] Fix build after 0df1546
- [flang][OpenMP] Add semantic check for target update (#71305)
- [libc][math] Add min/max/min_denorm/max_denorm constants to FPBits and clean up its constants return types. (#71298)
- [mlir][linalg] Add support for vectorizing dynamic elementwise named ops (#71454)
- [flang][openacc] Support variable from equivalence in data clauses (#71434)
- [LLDB] Don't forcefully initialize the process trace plugin (#71455)
- Add SANITIZER_CDECL to __tsan_check_no_mutexes_held (#71471)
- [mlir][sparse] implement loose-compressed/2:4 on direct IR codegen path (#71461)
- [clang][modules] Avoid modules diagnostics for `__has_include()` (#71450)
- [mlir][vector] Add leading unit dim folding patterns for masked transfers (#71466)
- [clang][CGObjCGNU] Remove no-op ptr-to-ptr bitcasts (NFC)
- [InstCombinePHI] Remove dead PHI on UnaryOperator (#71386)
- [flang][openacc] Correctly lower acc routine in interface block (#71451)
- [flang][openacc] Allow acc routine before implicit part (#71460)
- [Clang] Remove unneeded template keyword (#71435)
- Revert "[Clang] Remove unneeded template keyword" (#71478)
- Add GlobalISel sync-up meeting information
- [flang][OpenMP] Add semantic check for declare target (#71425)
- Add known and demanded bits support for zext nneg (#70858)
- [Clang] Add codegen option to add passbuilder callback functions (#70171)
- Reland "clang][DebugInfo] Emit global variable definitions for static data members with constant initializers (#70639)"
- Reland "[lldb][DWARFASTParserClang] Fetch constant value from variable defintion if available (#71004)"
- Reland "[lldb][test] Add FindGlobalVariables tests for C++ inline static data members (#70641)"
- [clang][examples] Remove unused variable 'key' in LLVMPrintFunctionNames.cpp (NFC)
- [lldb][test] TestVTableValue.py: skip base_class_ptr test case on older Clang versions
- [GlobalISel] Fall back for bf16 conversions. (#71470)
- [lldb][test] TestConstStaticIntegralMember.py: un-XFAIL on Linux (#71486)
- [NewPM] Remove AAEval Legacy Pass (#71358)
- [Github] Fix github automation script on empty descriptions (#71274)
- [NFC] Remove unused member function 'Error' from PCHValidator
- [Clang][CodeGen] Stoping emitting alignment assumes for `align_{up,down}`
- [mlir][sparse][gpu] add GPU BSR SDDMM check test (#71491)
- [X86] Add a EVEX256 macro to match with GCC and MSVC (#71317)
- AMDGPU: Port AMDGPUAttributor to new pass manager (#71349)
- [libc++] Make sure ranges algorithms and views handle boolean-testable correctly (#69378)
- [InstCombine] Split the FMul with reassoc into a helper function, NFC (#71493)
- [libc] Optimize mempcy size thresholds (#70049)
- Reapply "RegisterCoalescer: Add implicit-def of super register when coalescing SUBREG_TO_REG"
- RegisterCoalescer: Generate test checks
- [HWASAN] Add memset interceptor (#71244)
- [InterleavedAccessPass] Avoid optimizing load instructions if it has dead binop users (#71339)
- [flang][hlfir] Lower parent component in constant structure constructors (#71421)
- [RISCV] Disable performCombineVMergeAndVOps for PseduoVIOTA_M. (#71483)
- [IR] Remove FP cast constant expressions (#71408)
- [AArch64][GlobalISel] Remove -O0 from a legalizer test, which causes legalization failures to be silent.
- [clang][dataflow] Fix assert-fail when calling assignment operator with by-value parameter. (#71384)
- Improve error message for cmake failure (#71404)
- [lldb] Add template method for getting const or mutable regs from DynamicRegisterInfo (#71402)
- [bazel] Port for libc change bc7a3bd864be696217c4d11eddf16bed7646b60f
- [RISCV] Fix using undefined variable %pt2 in mask-reg-alloc.mir testcase (#70764)
- Revert "[lldb] Add template method for getting const or mutable regs from DynamicRegisterInfo (#71402)"
- [bazel] Fix the bazel build for 2400c54c37d5afdfec016b9a71f161ac10a49b31
- Reland "[lldb] Add template method for getting const or mutable regs from DynamicRegisterInfo (#71402)"
- [GlobalOpt] Cache whether CC is changeable (#71381)
- [lldb][test] Remove xfail for integral member test on Windows
- Reapply #2 [clang-repl] [test] Make an XFAIL more precise (#71168)
- [IR] Mark mul and ashr const exprs as undesirable
- [clang-repl] Fix BUILD_SHARED_LIBS symbols from libclangInterpreter on MinGW (#71393)
- [LLD] [COFF] Mark the symbol _tls_used as a GC root (#71336)
- [LLD] [COFF] Error out if new LTO objects are pulled in after the main LTO compilation (#71337)
- Revert "Reland [SimplifyCFG] Delete the unnecessary range check for small mask operation (#70542)"
- [LLD] [COFF] Fix deducing the machine type from LTO objects for ARM/Thumb (#71335)
- [MLIR] Use different constant expression in test (NFC)
- Revert "[IR] Mark mul and ashr const exprs as undesirable"
- [RISCV] Add tests for pseudos that shouldn't have vmerge folded into them. NFC
- [AArch64] Sink vscale calls into loops for better isel (#70304)
- [clang][ExtractAPI] Update availability serialization in SGF (#71418)
- [SpeculativeExecution] Add only-if-divergent-target pass option
- [clang][analyzer][NFC] Remove redundant code in StreamChecker (#71394)
- Reland: [AMDGPU] Remove Code Object V3 (#67118)
- [JITLink][AArch32] Tests for ELF::R_ARM_ABS32 and ELF::R_ARM_REL32
- Reapply: [lld] Restore "REQUIRES: amdgpu" in amdgpu-abi-version
- [Flang][OpenMP] Fix to support privatisation of alloc strings (#71204)
- Revert "[Flang][OpenMP] Fix to support privatisation of alloc strings (#71204)"
- [NFC][IRCE] Add unit test to show room for improvement (#71506)
- Revert "Revert "[Flang][OpenMP] Fix to support privatisation of alloc strings (#71204)""
- [analyzer] Improve diagnostics from ArrayBoundCheckerV2 (#70056)
- [InstCombine] Zero-extend shift amounts in narrow funnel shift ops
- [MLIR][OpenMP] Add check to see if map operand is of PtrType before creating LoadInst
- [libc][bazel] Add powf target and fix bazel overlay. (#71464)
- [clang] Improve `_Alignas` on a `struct` declaration diagnostic (#65638)
- [AMDGPU] Fix subtarget predicates for some V_MAD, V_FMA and V_DOT instructions. (#71194)
- [InstSimplify] Remove redundant simplifyAndOrOfICmpsWithLimitConst() fold (NFCI)
- [NFC][MLIR][OpenMP] Add test for lowering omp target parallel (#70795)
- RegisterCoalescer: Clear isSSA property
- [InstSimplify] Remove redundant simplifyAndOrOfICmpsWithZero() fold (NFCI)
- [mlir][memref] Add memref alias folding for masked transfers (#71476)
- Revert "Reapply "RegisterCoalescer: Add implicit-def of super register when coalescing SUBREG_TO_REG""
- Revert "RegisterCoalescer: Generate test checks"
- [clang][dataflow] Simplify flow conditions displayed in HTMLLogger. (#70848)
- [AMDGPU] PromoteAlloca: Handle load/store subvectors using non-constant indexes (#71505)
- [clang][dataflow] Fix -Wrange-loop-construct in DataflowAnalysisContext.cpp (NFC)
- Revert "Reland "clang][DebugInfo] Emit global variable definitions for static data members with constant initializers (#70639)""
- [C++20] [Modules] Don't import function bodies from other module units even with optimizations (#71031)
- Revert "[TSAN] Add __tsan_check_no_mutexes_held helper (#69372)"
- [SCEV] Extend isImpliedCondOperandsViaRanges to independent predicates (#71110)
- Disable UBSan vptr tests on Android.
- Test update after a7f35d
- [Clang][OpenMP] fixed crash due to invalid binary expression in checking atomic semantics (#71480)
- [Clang][SME2] Add multi-vector add/sub builtins (#69725)
- Silence diagnostics about not all control paths returning a value; NFC
- [indvars] Always fallback to truncation if AddRec widening fails (#70967)
- [InstCombine] Check FPMathOperator for Ctx before FMF check
- [RISCV][Clang][TargetParser] Support getting feature unaligned-scalar-mem from mcpu. (#71513)
- [NFC] Remove Type::getInt8PtrTy (#71029)
- [OpenMP][Offload] Automatically map indirect function pointers (#71462)
- [RISCV] Add processor definition for XiangShan-NanHu (#70294)
- [mlir][python] value casting (#69644)
- APFloat: Add some missing function declarations
- [clang] Remove no-op ptr-to-ptr bitcasts (NFC)
- [lldb] Fix calls to Type::getInt8PtrTy (#71561)
- [lldb/Interpreter] Make Scripted*Interface base class abstract (#71465)
- [JITLink][AArch32] Add test for ELF::R_ARM_THM_MOV{W_ABS_NC,T_ABS} (#70346)
- [mlir][vector] Remove obsolete mask docs in transfer_write op (#71490)
- [RISCV][GISel] Add support for G_FPTOSI/G_FPTOUI with F and D extensions.
- [libc][NFC] Remove libcpp include from atanf_test (#71449)
- [lldb] BreakpointResolver{*}::CreateFromStructuredData should return shared pointers (#71477)
- [clang][NFC] Add a missing comment to #71322 changes
- [CodeGen][MachineVerifier] Use TypeSize instead of unsigned for getRe… (#70881)
- [openacc] Remove duplicate operand from LoopOp getDataOperand (#71576)
- [lldb] Check for abstract methods implementation in Scripted Plugin Objects (#71260)
- [BOLT] Follow-up to "Fix incorrect basic block output addresses"
